### PR TITLE
Fix README install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
    ```bash
    git clone https://github.com/tsentelieros/EventCalendar.git
    cd event-calendar
+   ```
 
 ## ▶️ Εκτέλεση
    python -m app.main


### PR DESCRIPTION
## Summary
- close the bash block in the installation instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f5f8e71a8833283314d1d43ac04ec