### PR TITLE
Fix style, menu return, docs and tests; revert requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## 🚀 Προαπαιτούμενα
 
-- Python 3.8+  
+ - Python 3.9+
 - Git  
 - (Προτείνεται) Virtual environment  
 
@@ -41,6 +41,7 @@
    ```bash
    git clone https://github.com/tsentelieros/EventCalendar.git
    cd event-calendar
+   ```
 
 ## ▶️ Εκτέλεση
    python -m app.main

--- a/app/pages/calendar_page.py
+++ b/app/pages/calendar_page.py
@@ -252,7 +252,14 @@ class CalendarPage(ttk.Frame):
         form.start_var.set(ev.start_time.strftime('%H:%M'))
         form.end_var.set(ev.end_time.strftime('%H:%M'))
         form.location_entry.insert(0, ev.location or '')
-        form.repeat_var.set(ev.recurrence.value)
+        greek_map = {
+            Recurrence.NONE: "Καμία",
+            Recurrence.DAILY: "Ημερήσια",
+            Recurrence.WEEKLY: "Εβδομαδιαία",
+            Recurrence.MONTHLY: "Μηνιαία",
+            Recurrence.YEARLY: "Ετήσια",
+        }
+        form.repeat_var.set(greek_map.get(ev.recurrence, "Καμία"))
         if ev.recurrence != Recurrence.NONE and ev.recurrence_end:
             form.repeat_until_entry.config(state='normal')
             form.repeat_until_entry.set_date(ev.recurrence_end)

--- a/app/pages/login.py
+++ b/app/pages/login.py
@@ -55,7 +55,6 @@ class LoginPage(ttk.Frame):
             command=lambda: controller.show_frame("SignupPage")
         )
         self.signup_btn.grid(row=5, column=0, columnspan=2, sticky="we", pady=(5,0))
-        # Test comment
         # Παρακολούθηση αλλαγών για ενεργοποίηση κουμπιού
         self.username_entry.bind("<KeyRelease>", self.update_login_state)
         self.password_entry.bind("<KeyRelease>", self.update_login_state)

--- a/app/pages/menu.py
+++ b/app/pages/menu.py
@@ -17,3 +17,4 @@ class MenuBar:
         logout_menu.add_command(label="Έξοδος",command=exit_func)
 
         controller.config(menu=menu_bar)
+        return menu_bar

--- a/app/pages/signup.py
+++ b/app/pages/signup.py
@@ -34,7 +34,12 @@ class SignupPage(ttk.Frame):
 
         # Sign up button (disabled until valid input)
         self.signup_btn = ttk.Button(
-            self, text="Sign up", style="Login.TButton", state="disabled",cursor="hand2", command=self.attempt_signup
+            self,
+            text="Sign up",
+            style="Primary.TButton",
+            state="disabled",
+            cursor="hand2",
+            command=self.attempt_signup,
         )
         self.signup_btn.grid(row=4, column=0, columnspan=2, pady=10)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,0 +1,58 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import controllers
+from app.models import Base, Event, Recurrence
+from datetime import date, time
+
+@pytest.fixture
+def db_session(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    session = Session()
+    monkeypatch.setattr(controllers, 'session', session)
+    yield session
+    session.close()
+
+
+def test_create_event_overlap(db_session):
+    """Creating an overlapping event should raise ValueError."""
+    controllers.create_event(
+        title='A',
+        description='first',
+        date_=date(2024, 1, 1),
+        start_time_=time(9, 0),
+        end_time_=time(10, 0),
+    )
+    with pytest.raises(ValueError):
+        controllers.create_event(
+            title='B',
+            description='overlap',
+            date_=date(2024, 1, 1),
+            start_time_=time(9, 30),
+            end_time_=time(10, 30),
+        )
+
+    events = db_session.query(Event).all()
+    assert len(events) == 1
+    assert events[0].title == 'A'
+
+
+def test_create_event_with_recurrence(db_session):
+    """Events should store recurrence information correctly."""
+    ev = controllers.create_event(
+        title='R',
+        description='recurring',
+        date_=date(2024, 1, 2),
+        start_time_=time(10, 0),
+        end_time_=time(11, 0),
+        recurrence=Recurrence.DAILY,
+        recurrence_end=date(2024, 1, 5),
+    )
+    stored = db_session.query(Event).get(ev.id)
+    assert stored.recurrence == Recurrence.DAILY
+    assert stored.recurrence_end == date(2024, 1, 5)
+    assert stored.title == 'R'
+    assert stored.date == date(2024, 1, 2)


### PR DESCRIPTION
## Summary
- close code block in README
- return the menubar from `MenuBar.build`
- fix disabled signup button style
- show Greek recurrence labels when editing events
- remove stray debug comment
- add controller tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f5de279c883329e6b5ba47229ce77